### PR TITLE
Revert console error message warning

### DIFF
--- a/docs/nginx-one-2.mdx
+++ b/docs/nginx-one-2.mdx
@@ -794,8 +794,6 @@ the Config Sync Group.
 
     ![Final Diff](media/lab5-15.png)
 
-    > :warning: Note: Due to a temporary issue in the NGINX One Console, you may receive [this error](https://github.com/f5devcentral/nginx-one-ga-lab/issues/27) when publishing the configuration. If so, you will temporarily have to skip this section of the lab, and jump right to the [Review](#review) section.
-
 1. Now let's add two new NGINX Open Source instances pre-configured to join this Config Sync Group. Select *Run* for each NGINX OSS instance below. As a convenience, the dataplane key and Config Sync Group have already been provided to the containers.
 
     <DockerContainer>


### PR DESCRIPTION
No longer needed, based on closure of issue #30 